### PR TITLE
Add DKMS module configuration to circumvent signing issue in Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ sudo apt install dkms
 sudo modprobe xmm7360_usb
 ```
 
-If you want to remove this module from dkms tree, use `sudo dkms remove -m xmm7360_usb -v 0.1--all`
+If you want to remove this module from dkms tree, use `sudo dkms remove -m xmm7360_usb -v 0.1 --all`

--- a/README.md
+++ b/README.md
@@ -63,18 +63,21 @@ sign-file: certs/signing_key.pem: No such file or directory
 ```
 
 1. Install dkms
+
 ```
 sudo apt install dkms
 ```
 
-1. Install xmm7360 module by dkms
+2. Install xmm7360 module by dkms
+
 ```
 ./install_dkms.sh
 ```
 
-1. Load xmm7360 module
+3. Load xmm7360 module
+
 ```
 sudo modprobe xmm7360_usb
 ```
 
-If you want to remove this module from dkms tree, use `sudo dkms remove -m xmm7360_usb -v 1.0 --all`
+If you want to remove this module from dkms tree, use `sudo dkms remove -m xmm7360_usb -v 0.1--all`

--- a/README.md
+++ b/README.md
@@ -49,3 +49,32 @@ AT+CFUN=15
 
 Everything simply worked on my machine from that onwards, and the automatically
 loaded module makes sure that the modem stays in USB mode even through reboots.
+
+## DKMS Module
+
+If you encounter something like following while executing `sudo make install`, you may try installing by DKMS module.
+
+```
+At main.c:160:
+- SSL error:02001002:system library:fopen:No such file or directory: ../crypto/bio/bss_file.c:69
+- SSL error:2006D080:BIO routines:BIO_new_file:no such file: ../crypto/bio/bss_file.c:76
+sign-file: certs/signing_key.pem: No such file or directory
+  DEPMOD  5.4.0-40-generic
+```
+
+1. Install dkms
+```
+sudo apt install dkms
+```
+
+1. Install xmm7360 module by dkms
+```
+./install_dkms.sh
+```
+
+1. Load xmm7360 module
+```
+sudo modprobe xmm7360_usb
+```
+
+If you want to remove this module from dkms tree, use `sudo dkms remove -m xmm7360_usb -v 1.0 --all`

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,0 +1,8 @@
+MAKE="make -C ./ KERNELDIR=/lib/modules/${kernelver}/build"
+CLEAN="make -C ./ clean"
+BUILT_MODULE_NAME=xmm7360_usb
+BUILT_MODULE_LOCATION=./
+PACKAGE_NAME=xmm7360_usb
+PACKAGE_VERSION=1.0
+DEST_MODULE_LOCATION=/kernel/drivers/other
+AUTOINSTALL=yes

--- a/install_dkms.sh
+++ b/install_dkms.sh
@@ -1,0 +1,5 @@
+sudo mkdir /usr/src/xmm7360_usb-0.1
+sudo cp -r . /usr/src/xmm7360_usb-0.1
+sudo dkms add -m xmm7360_usb/0.1
+sudo dkms build -m xmm7360_usb -v 0.1
+sudo dkms install -m xmm7360_usb -v 0.1

--- a/uninstall_dkms.sh
+++ b/uninstall_dkms.sh
@@ -1,0 +1,2 @@
+sudo dkms remove -m xmm7360_usb -v 0.1 --all
+sudo rm -rf  /usr/src/xmm7360_usb-0.1


### PR DESCRIPTION
Tested on my computer with Ubuntu 20.04 / Kernel 5.4.0-40-generic